### PR TITLE
Fix: use cross-platform null device for ChromeDriver log suppression

### DIFF
--- a/services/scraping_utils.py
+++ b/services/scraping_utils.py
@@ -1,3 +1,4 @@
+import os
 from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options
 from selenium.common.exceptions import NoSuchElementException
@@ -15,7 +16,8 @@ options.add_argument('--ignore-certificate-errors=yes')
 options.add_argument("--log-level=3")
 
 # Setting up service
-service = Service(ChromeDriverManager().install(), log_output='nul')
+log_output = 'nul' if os.name == 'nt' else '/dev/null'
+service = Service(ChromeDriverManager().install(), log_output=log_output)
 
 def find_by_xpath_or_None(driver, *xpaths):
     """returns the text inside and elemnt by its xPath"""


### PR DESCRIPTION
## Problem
`log_output='nul'` in `scraping_utils.py` is a Windows-only path. On Linux/macOS, `nul` does not exist — the correct null device is `/dev/null`. This causes ChromeDriver log suppression to fail silently on non-Windows systems.

## Changes
- Added `import os`
- Replaced hardcoded `'nul'` with a platform check using `os.name` to set the correct null device path per OS

## Testing
Tested on Windows — server starts correctly, no errors on startup.

Fixes #3 